### PR TITLE
Fix git repo url in Apache Spark stackscript

### DIFF
--- a/scripts/ss.sh
+++ b/scripts/ss.sh
@@ -22,7 +22,7 @@ fi
 export DEBIAN_FRONTEND=noninteractive
 
 # git repo
-export GIT_REPO="https://github.com/akamai-compute-marketplace/marketplace-apache-spark-occ.git"
+export GIT_REPO="https://github.com/akamai-compute-marketplace/apache-spark-occ.git"
 export WORK_DIR="/tmp/marketplace-apache-spark-occ"
 export RUN_DIR="/usr/local/bin/run"
 export UUID=$(uuidgen | awk -F - '{print $1}')


### PR DESCRIPTION
The Spark Cluster was failing to deploy because the Username was incorrect:
```
Cloning into '/tmp/marketplace-apache-spark-occ'...
fatal: could not read Username for 'https://github.com/': No such device or address
```

The GIT_REPO URL was incorrectly listed as `marketplace-apache-spark-occ.git`
When it should be: `apache-spark-occ.git`

This has been fixed in admin already and tested successfully. 