### PR TITLE
Spark - change url path to match new location in apache archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ A Let's Encrypt Certificate is installed in the NGINX configuration. Using NGINX
 | UFW | | Uncomplicated Firewall for managing firewall rules |
 | Fail2ban | | Intrusion prevention software framework for protection against brute-force attacks |
 
+## Spark Shell
+
+The Spark Shell is an interactive shell that comes pre-installed with your Apache Spark cluster. It provides a powerful REPL (Read-Eval-Print Loop) environment where you can interactively analyze data using Scala. The shell is particularly useful for data exploration, prototyping algorithms, and testing Spark functionality in real-time.
+
+To start the Spark Shell, simply open a terminal on the master node and run:
+
+```bash
+spark-shell
+```
+
+This will launch an interactive Scala console with Spark context (`sc`) and Spark session (`spark`) automatically initialized. You can immediately start executing Spark operations, such as loading data, performing transformations, and running SQL queries.
+
 ## Use our API
 
 Customers can choose to the deploy the Apache Spark app through the Linode Marketplace or directly using API. Before using the commands below, you will need to create an API token or configure linode-cli on an environment.
@@ -87,6 +99,16 @@ linode-cli linodes create \
   --private_ip true \
   --region ${REGION} \
   --root_pass '${ROOT_PASS}' \
+  --stackscript_data '{"add_ssh_keys": "yes","cluster_size":"3","token_password":"${TOKEN_PASSWORD}","cluster_name":"${CLUSTER_NAME}","sudo_username":"${SUDO_USERNAME}","soa_email_address":"${SOA_EMAIL_ADDRESS}", "domain":"${DOMAIN}"}' \
+  --stackscript_id 1403818 \
+  --tags mytag \
+  --type g6-standard-2
+
+```
+
+## Resources
+- [Create Linode via API](https://www.linode.com/docs/api/linode-instances/#linode-create)
+- [Stackscript referece](https://www.linode.com/docs/guides/writing-scripts-for-use-with-linode-stackscripts-a-tutorial/#user-defined-fields-udfs)
   --stackscript_data '{"add_ssh_keys": "yes","cluster_size":"3","token_password":"${TOKEN_PASSWORD}","cluster_name":"${CLUSTER_NAME}","sudo_username":"${SUDO_USERNAME}","soa_email_address":"${SOA_EMAIL_ADDRESS}", "domain":"${DOMAIN}"}' \
   --stackscript_id 1403818 \
   --tags mytag \

--- a/roles/common/tasks/create_dns_record.yml
+++ b/roles/common/tasks/create_dns_record.yml
@@ -40,8 +40,6 @@
     var: ip_address
   when: domain is defined
 
-# loop through domains the provided API token has grants to. Creating an A record without a zone, or creating a duplicate zone will fail the play.
-# or creating a duplicate zone will fail the play.
 - name: check existence of domain zone
   block:
     - name: lookup domain info

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 # roles/common/tasks
-# common tasks for all linodes
 - name: apt update
   apt:
     update_cache: yes

--- a/roles/spark/tasks/install_spark.yml
+++ b/roles/spark/tasks/install_spark.yml
@@ -3,11 +3,6 @@
     name: openjdk-11-jdk
     state: present
 
-# - name: download Spark
-#   get_url:
-#     url: "https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz"
-#     dest: "/tmp/spark-3.4.3-bin-hadoop3.tgz"
-
 - name: Download Spark with fallback
   block:
     - name: Try downloading Spark from main repository
@@ -20,14 +15,6 @@
         url: "https://archive.apache.org/dist/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz"
         dest: "/tmp/spark-3.5.3-bin-hadoop3.tgz"
 
-# - name: extract spark
-#   unarchive:
-#     src: "/tmp/spark-3.4.3-bin-hadoop3.tgz"
-#     dest: "{{ spark_home }}"
-#     owner: spark
-#     group: spark
-#     remote_src: yes
-
 - name: extract spark
   unarchive:
     src: "/tmp/spark-3.5.3-bin-hadoop3.tgz"
@@ -36,28 +23,14 @@
     group: spark
     remote_src: yes
 
-# - name: move spark download to spark home directory
-#   shell:
-#     cmd: mv /opt/spark/spark-3.4.3-bin-hadoop3/* /opt/spark
-
 - name: move spark download to spark home directory
   shell:
     cmd: mv /opt/spark/spark-3.5.3-bin-hadoop3/* /opt/spark
-
-# - name: Clean up downloaded archive
-#   file:
-#     path: "/tmp/spark-3.4.3-bin-hadoop3.tgz"
-#     state: absent
 
 - name: Clean up downloaded archive
   file:
     path: "/tmp/spark-3.5.3-bin-hadoop3.tgz"
     state: absent
-
-# - name: remove /opt/spark/spark-3.4.3-bin-hadoop3
-#   file:
-#     path: "/opt/spark/spark-3.4.3-bin-hadoop3.tgz"
-#     state: absent
 
 - name: remove /opt/spark/spark-3.5.3-bin-hadoop3
   file:

--- a/roles/spark/tasks/install_spark.yml
+++ b/roles/spark/tasks/install_spark.yml
@@ -3,31 +3,65 @@
     name: openjdk-11-jdk
     state: present
 
-- name: download Spark
-  get_url:
-    url: "https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz"
-    dest: "/tmp/spark-3.4.3-bin-hadoop3.tgz"
+# - name: download Spark
+#   get_url:
+#     url: "https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz"
+#     dest: "/tmp/spark-3.4.3-bin-hadoop3.tgz"
+
+- name: Download Spark with fallback
+  block:
+    - name: Try downloading Spark from main repository
+      get_url:
+        url: "https://downloads.apache.org/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz"
+        dest: "/tmp/spark-3.5.3-bin-hadoop3.tgz"
+  rescue:
+    - name: Download Spark from archive repository
+      get_url:
+        url: "https://archive.apache.org/dist/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz"
+        dest: "/tmp/spark-3.5.3-bin-hadoop3.tgz"
+
+# - name: extract spark
+#   unarchive:
+#     src: "/tmp/spark-3.4.3-bin-hadoop3.tgz"
+#     dest: "{{ spark_home }}"
+#     owner: spark
+#     group: spark
+#     remote_src: yes
 
 - name: extract spark
   unarchive:
-    src: "/tmp/spark-3.4.3-bin-hadoop3.tgz"
+    src: "/tmp/spark-3.5.3-bin-hadoop3.tgz"
     dest: "{{ spark_home }}"
     owner: spark
     group: spark
     remote_src: yes
 
+# - name: move spark download to spark home directory
+#   shell:
+#     cmd: mv /opt/spark/spark-3.4.3-bin-hadoop3/* /opt/spark
+
 - name: move spark download to spark home directory
   shell:
-    cmd: mv /opt/spark/spark-3.4.3-bin-hadoop3/* /opt/spark
+    cmd: mv /opt/spark/spark-3.5.3-bin-hadoop3/* /opt/spark
+
+# - name: Clean up downloaded archive
+#   file:
+#     path: "/tmp/spark-3.4.3-bin-hadoop3.tgz"
+#     state: absent
 
 - name: Clean up downloaded archive
   file:
-    path: "/tmp/spark-3.4.3-bin-hadoop3.tgz"
+    path: "/tmp/spark-3.5.3-bin-hadoop3.tgz"
     state: absent
 
-- name: remove /opt/spark/spark-3.4.3-bin-hadoop3
+# - name: remove /opt/spark/spark-3.4.3-bin-hadoop3
+#   file:
+#     path: "/opt/spark/spark-3.4.3-bin-hadoop3.tgz"
+#     state: absent
+
+- name: remove /opt/spark/spark-3.5.3-bin-hadoop3
   file:
-    path: "/opt/spark/spark-3.4.3-bin-hadoop3.tgz"
+    path: "/opt/spark/spark-3.5.3-bin-hadoop3.tgz"
     state: absent
 
 - name: create spark configuration directory

--- a/roles/spark/tasks/install_spark.yml
+++ b/roles/spark/tasks/install_spark.yml
@@ -5,7 +5,7 @@
 
 - name: download Spark
   get_url:
-    url: "https://downloads.apache.org/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz"
+    url: "https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz"
     dest: "/tmp/spark-3.4.3-bin-hadoop3.tgz"
 
 - name: extract spark

--- a/roles/spark/tasks/install_spark.yml
+++ b/roles/spark/tasks/install_spark.yml
@@ -1,3 +1,4 @@
+---
 - name: install Java
   apt:
     name: openjdk-11-jdk

--- a/roles/spark/tasks/user.yml
+++ b/roles/spark/tasks/user.yml
@@ -1,6 +1,5 @@
 ---
 # Create spark system user and group
-
 - name: check if spark group exists
   getent:
     database: group


### PR DESCRIPTION
Spark version 3.4.3 has been moved to their archive.

Old URL:
https://downloads.apache.org/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz

Now at:
https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz 

Fixed and tested:
```
RUNNING HANDLER [common : restart ssh] *****************************************
changed: [172.235.150.254] => {"changed": true, "enabled": true, "name": "ssh",}
changed: [172.235.143.56] => {"changed": true, "enabled": true, "name": "ssh", }
changed: [localhost] => {"changed": true, "enabled": true, "name": "ssh", "stat}

PLAY RECAP *********************************************************************
172.235.143.56             : ok=38   changed=28   unreachable=0    failed=0
172.235.150.254            : ok=38   changed=30   unreachable=0    failed=0
localhost                  : ok=71   changed=53   unreachable=0    failed=0
```